### PR TITLE
Fallback to allowed_profiles to validate securityContext.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 ## Description
 
-This policy provides a replacement for the Pod Security Policy that deals with seccomp profiles.
+This policy provides a replacement for the Pod Security Policy that deals with
+seccomp profiles.
 
-Prior to Kubernetes 1.19, seccomp profiles could be defined only via Pod `annotations`. Starting from Kubernetes 1.19 the seccomp profiles can be managed via the `securityContext` field of Pods and Containers.
+Prior to Kubernetes 1.19, seccomp profiles could be defined only via Pod
+`annotations`. Starting from Kubernetes 1.19 the seccomp profiles can be managed
+via the `securityContext` field of Pods and Containers.
 
-Note well: the seccomp annotations are deprecated and will be dropped starting from Kubernetes 1.25.
+Note well: the seccomp annotations are deprecated and will be dropped starting
+from Kubernetes 1.25.
 
-This policy can handle both seccomp policies expressed via `annotations` and via `securityContext`.
 
 ## Settings
 
@@ -17,11 +20,16 @@ This policy has some configurations:
 `container.seccomp.security.alpha.kubernetes.io/<container>` and
 `seccomp.security.alpha.kubernetes.io/pod`.
 - `profile_types`: Define the allowed values to be set in the seccomp type
-- `profile_types`: Define the allowed values to be set in the seccomp type
 in the security context of a container or of the Pod.
 - `localhost_profiles`: Define the allowed localhost profiles. This is used only
 when the "Localhost" type is allowed inside of the security context.
 
+This policy can handle both seccomp policies expressed via `annotations` and
+via `securityContext`. In later Kubernetes version, it will populate the
+`securityContext` when the user define only the annotations. For this reason,
+if the user does not define the `profile_types` and `localhost_profiles` settings,
+the policy will fall-back to the `allowed_profiles`. Validating the containers
+`securityContext` against it. The following two settings are equivalent:
 
 ```yaml
 apiVersion: policies.kubewarden.io/v1alpha2
@@ -51,10 +59,40 @@ spec:
       - test
 ```
 
+
+```yaml
+apiVersion: policies.kubewarden.io/v1alpha2
+kind: ClusterAdmissionPolicy
+metadata:
+  name: psp-seccomp
+spec:
+  policyServer: default
+  module: registry://ghcr.io/kubewarden/policies/seccomp-psp:v0.1.0
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: false
+  settings:
+    allowed_profiles:
+      - runtime/default
+      - docker/default
+      - localhost/test
+```
+
+As said before, you do not need to declare the `profile_types` and
+`localhost_profiles`. If you decided to use only the `allowed_profiles`
+settings you can get the same results.
+
+
 ## Examples
 
-With the yaml content from the settings section, the following pods will
+With the yaml settings described in the settings section the following pods will
 be accepted:
+
 
 ```yaml
 apiVersion: v1

--- a/metadata.yml
+++ b/metadata.yml
@@ -18,13 +18,16 @@ annotations:
 
     ## Description
 
-    This policy provides a replacement for the Pod Security Policy that deals with seccomp profiles.
+    This policy provides a replacement for the Pod Security Policy that deals with
+    seccomp profiles.
 
-    Prior to Kubernetes 1.19, seccomp profiles could be defined only via Pod `annotations`. Starting from Kubernetes 1.19 the seccomp profiles can be managed via the `securityContext` field of Pods and Containers.
+    Prior to Kubernetes 1.19, seccomp profiles could be defined only via Pod
+    `annotations`. Starting from Kubernetes 1.19 the seccomp profiles can be managed
+    via the `securityContext` field of Pods and Containers.
 
-    Note well: the seccomp annotations are deprecated and will be dropped starting from Kubernetes 1.25.
+    Note well: the seccomp annotations are deprecated and will be dropped starting
+    from Kubernetes 1.25.
 
-    This policy can handle both seccomp policies expressed via `annotations` and via `securityContext`.
 
     ## Settings
 
@@ -33,11 +36,16 @@ annotations:
     `container.seccomp.security.alpha.kubernetes.io/<container>` and
     `seccomp.security.alpha.kubernetes.io/pod`.
     - `profile_types`: Define the allowed values to be set in the seccomp type
-    - `profile_types`: Define the allowed values to be set in the seccomp type
     in the security context of a container or of the Pod.
     - `localhost_profiles`: Define the allowed localhost profiles. This is used only
     when the "Localhost" type is allowed inside of the security context.
 
+    This policy can handle both seccomp policies expressed via `annotations` and
+    via `securityContext`. In later Kubernetes version, it will populate the
+    `securityContext` when the user define only the annotations. For this reason,
+    if the user does not define the `profile_types` and `localhost_profiles` settings,
+    the policy will fall-back to the `allowed_profiles`. Validating the containers
+    `securityContext` against it. The following two settings are equivalent:
 
     ```yaml
     apiVersion: policies.kubewarden.io/v1alpha2
@@ -67,10 +75,40 @@ annotations:
           - test
     ```
 
+
+    ```yaml
+    apiVersion: policies.kubewarden.io/v1alpha2
+    kind: ClusterAdmissionPolicy
+    metadata:
+      name: psp-seccomp
+    spec:
+      policyServer: default
+      module: registry://ghcr.io/kubewarden/policies/seccomp-psp:v0.1.0
+      rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        operations:
+        - CREATE
+        - UPDATE
+      mutating: false
+      settings:
+        allowed_profiles:
+          - runtime/default
+          - docker/default
+          - localhost/test
+    ```
+
+    As said before, you do not need to declare the `profile_types` and
+    `localhost_profiles`. If you decided to use only the `allowed_profiles`
+    settings you can get the same results.
+
+
     ## Examples
 
-    With the yaml content from the settings section, the following pods will
+    With the yaml settings described in the settings section the following pods will
     be accepted:
+
 
     ```yaml
     apiVersion: v1


### PR DESCRIPTION
When the user defines the seccomp profile using annotations, later 
Kubernetes versions will populate the securityContext field
automatically with the equivalent configuration. This can cause
rejections when the users are using the seccomp policy with no
`profile_types` and `localhost_profiles` configuration.

To mitigate this, the policy now fall-back to the `allowed_profiles`
settings when it cannot validate the securityContext configuration with
the `localhost_profiles` and `localhost_profiles` settings.

Closes #6 