### PR TITLE
Bump v0.1.4 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "seccomp-psp-policy"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seccomp-psp-policy"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["José Guilherme Vanz <jvanz@jvanz.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,28 +4,28 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.3
+version: 0.1.4
 name: seccomp-psp
 displayName: Seccomp PSP
-createdAt: 2023-03-21T11:09:47.967996564Z
+createdAt: 2023-07-07T18:41:38.173364191Z
 description: Pod Security Policy that controls usage of Seccomp profile
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/seccomp-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/seccomp-psp:v0.1.3
+  image: ghcr.io/kubewarden/policies/seccomp-psp:v0.1.4
 keywords:
 - psp
 - seccomp
 links:
 - name: policy
-  url: https://github.com/kubewarden/seccomp-psp-policy/releases/download/v0.1.3/policy.wasm
+  url: https://github.com/kubewarden/seccomp-psp-policy/releases/download/v0.1.4/policy.wasm
 - name: source
   url: https://github.com/kubewarden/seccomp-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/seccomp-psp:v0.1.3
+  kwctl pull ghcr.io/kubewarden/policies/seccomp-psp:v0.1.4
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.4 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.4

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
